### PR TITLE
Adds @escaping to closures

### DIFF
--- a/Stevia/Stevia/Stevia.xcodeproj/project.pbxproj
+++ b/Stevia/Stevia/Stevia.xcodeproj/project.pbxproj
@@ -227,14 +227,17 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Sacha Durand Saint Omer";
 				TargetAttributes = {
 					9991C8541BDB6C8B007D9B75 = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0800;
 					};
 					99B621771BF75D0E00A54B05 = {
 						CreatedOnToolsVersion = 7.1;
+						DevelopmentTeam = 4TATSTJ3J3;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -354,8 +357,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -402,8 +407,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -444,6 +451,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.s4cha.Stevia;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -461,28 +469,35 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.s4cha.Stevia;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
 		99B621801BF75D0E00A54B05 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = 4TATSTJ3J3;
 				INFOPLIST_FILE = SteviaTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.s4cha.webApp.SteviaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		99B621811BF75D0E00A54B05 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = 4TATSTJ3J3;
 				INFOPLIST_FILE = SteviaTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.s4cha.webApp.SteviaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Stevia/Stevia/Stevia.xcodeproj/xcshareddata/xcschemes/Stevia.xcscheme
+++ b/Stevia/Stevia/Stevia.xcodeproj/xcshareddata/xcschemes/Stevia.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Stevia/Stevia/Stevia/Source/Stevia+Alignment.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Alignment.swift
@@ -23,7 +23,7 @@ import UIKit
  - Returns: The array of views, enabling chaining,
  
  */
-public func alignHorizontally(views: UIView...) -> [UIView] {
+@discardableResult public func alignHorizontally(_ views: UIView...) -> [UIView] {
     return alignHorizontally(views)
 }
 
@@ -42,8 +42,8 @@ public func alignHorizontally(views: UIView...) -> [UIView] {
  - Returns: The array of views, enabling chaining,
  
  */
-public func alignHorizontally(views: [UIView]) -> [UIView] {
-    align(.Horizontal, views: views)
+@discardableResult public func alignHorizontally(_ views: [UIView]) -> [UIView] {
+    align(.horizontal, views: views)
     return views
 }
 
@@ -57,7 +57,7 @@ public func alignHorizontally(views: [UIView]) -> [UIView] {
  - Returns: The array of views, enabling chaining,
  
  */
-public func alignVertically(views: UIView...) {
+public func alignVertically(_ views: UIView...) {
     alignVertically(views)
 }
 
@@ -71,8 +71,8 @@ public func alignVertically(views: UIView...) {
  - Returns: The array of views, enabling chaining,
  
  */
-public func alignVertically(views: [UIView]) {
-    align(.Vertical, views: views)
+public func alignVertically(_ views: [UIView]) {
+    align(.vertical, views: views)
 }
 
 /** Aligns the center of two views
@@ -82,7 +82,7 @@ public func alignVertically(views: [UIView]) {
  alignCenter(button, with:image)
  ```
  */
-public func alignCenter(v1: UIView, with v2: UIView) {
+public func alignCenter(_ v1: UIView, with v2: UIView) {
     alignHorizontally(v1, with: v2)
     alignVertically(v1, with: v2)
 }
@@ -95,8 +95,8 @@ public func alignCenter(v1: UIView, with v2: UIView) {
  ```
  
  */
-public func alignHorizontally(v1: UIView, with v2: UIView, offset: CGFloat = 0) {
-    align(.Horizontal, v1: v1, with: v2, offset: offset)
+public func alignHorizontally(_ v1: UIView, with v2: UIView, offset: CGFloat = 0) {
+    align(.horizontal, v1: v1, with: v2, offset: offset)
 }
 
 /** Aligns two views Vertically (on the Y Axis)
@@ -107,15 +107,15 @@ public func alignHorizontally(v1: UIView, with v2: UIView, offset: CGFloat = 0) 
  ```
  
  */
-public func alignVertically(v1: UIView, with v2: UIView, offset: CGFloat = 0) {
-    align(.Vertical, v1: v1, with: v2, offset: offset)
+public func alignVertically(_ v1: UIView, with v2: UIView, offset: CGFloat = 0) {
+    align(.vertical, v1: v1, with: v2, offset: offset)
 }
 
-private func align(axis: UILayoutConstraintAxis, views: [UIView]) {
-    for (i, v) in views.enumerate() {
+private func align(_ axis: UILayoutConstraintAxis, views: [UIView]) {
+    for (i, v) in views.enumerated() {
         if views.count > i+1 {
             let v2 = views[i+1]
-            if axis == .Horizontal {
+            if axis == .horizontal {
                 alignHorizontally(v, with: v2)
             } else {
                 alignVertically(v, with: v2)
@@ -124,9 +124,9 @@ private func align(axis: UILayoutConstraintAxis, views: [UIView]) {
     }
 }
 
-private func align(axis: UILayoutConstraintAxis, v1: UIView, with v2: UIView, offset: CGFloat) {
+private func align(_ axis: UILayoutConstraintAxis, v1: UIView, with v2: UIView, offset: CGFloat) {
     if let spv = v1.superview {
-        let center: NSLayoutAttribute = axis == .Horizontal ? .CenterY : .CenterX
+        let center: NSLayoutAttribute = axis == .horizontal ? .centerY : .centerX
         let c = constraint(item: v1, attribute: center, toItem: v2, constant:offset)
         spv.addConstraint(c)
     }

--- a/Stevia/Stevia/Stevia/Source/Stevia+Center.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Center.swift
@@ -20,7 +20,7 @@ public extension UIView {
      - Returns: Itself, enabling chaining,
      
      */
-    public func centerInContainer() -> UIView {
+    @discardableResult public func centerInContainer() -> UIView {
         if let spv = superview {
             alignCenter(self, with: spv)
         }
@@ -37,7 +37,7 @@ public extension UIView {
      - Returns: Itself, enabling chaining,
      
      */
-    public func centerHorizontally() -> UIView {
+    @discardableResult public func centerHorizontally() -> UIView {
         if let spv = superview {
             alignVertically([self, spv])
         }
@@ -54,7 +54,7 @@ public extension UIView {
      - Returns: Itself, enabling chaining,
      
      */
-    public func centerVertically() -> UIView {
+    @discardableResult public func centerVertically() -> UIView {
         if let spv = superview {
             alignHorizontally([self, spv])
         }
@@ -71,7 +71,7 @@ public extension UIView {
      - Returns: Itself, enabling chaining,
      
      */
-    public func centerHorizontally(offset: CGFloat) -> UIView {
+    @discardableResult public func centerHorizontally(_ offset: CGFloat) -> UIView {
         if let spv = superview {
             alignVertically(self, with: spv, offset: offset)
         }
@@ -88,7 +88,7 @@ public extension UIView {
      - Returns: Itself, enabling chaining,
      
      */
-    public func centerVertically(offset: CGFloat) -> UIView {
+    @discardableResult public func centerVertically(_ offset: CGFloat) -> UIView {
         if let spv = superview {
             alignHorizontally(self, with: spv, offset: offset)
         }

--- a/Stevia/Stevia/Stevia/Source/Stevia+Constraints.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Constraints.swift
@@ -12,7 +12,7 @@ import UIKit
 
 public extension UIView {
     
-    @available(*, deprecated=2.2.1, message="Use 'addConstraint' instead")
+    @available(*, deprecated: 2.2.1, message: "Use 'addConstraint' instead")
     /**
      Helper for creating and adding NSLayoutConstraint but with default values provided.
      
@@ -37,7 +37,7 @@ public extension UIView {
      */
     public func c(item view1: AnyObject,
         attribute attr1: NSLayoutAttribute,
-        relatedBy: NSLayoutRelation = .Equal,
+        relatedBy: NSLayoutRelation = .equal,
         toItem view2: AnyObject? = nil,
         attribute attr2: NSLayoutAttribute? = nil,
         multiplier: CGFloat = 1,
@@ -73,9 +73,9 @@ public extension UIView {
      
      - Returns: The NSLayoutConstraint created.
      */
-    public func addConstraint(item view1: AnyObject,
+    @discardableResult public func addConstraint(item view1: AnyObject,
                        attribute attr1: NSLayoutAttribute,
-                                 relatedBy: NSLayoutRelation = .Equal,
+                                 relatedBy: NSLayoutRelation = .equal,
                                  toItem view2: AnyObject? = nil,
                                         attribute attr2: NSLayoutAttribute? = nil,
                                                   multiplier: CGFloat = 1,
@@ -109,7 +109,7 @@ public extension UIView {
  */
 public func constraint(item view1: AnyObject,
     attribute attr1: NSLayoutAttribute,
-    relatedBy: NSLayoutRelation = .Equal,
+    relatedBy: NSLayoutRelation = .equal,
     toItem view2: AnyObject? = nil,
     attribute attr2: NSLayoutAttribute? = nil, // Not an attribute??
     multiplier: CGFloat = 1,
@@ -134,13 +134,13 @@ public extension UIView {
      button.followEdges(image)
      ```
      */
-    public func followEdges(otherView: UIView) {
+    @discardableResult public func followEdges(_ otherView: UIView) {
         if let spv = superview {
             let cs = [
-                constraint(item: self, attribute: .Top, toItem: otherView),
-                constraint(item: self, attribute: .Right, toItem: otherView),
-                constraint(item: self, attribute: .Bottom, toItem: otherView),
-                constraint(item: self, attribute: .Left, toItem: otherView)
+                constraint(item: self, attribute: .top, toItem: otherView),
+                constraint(item: self, attribute: .right, toItem: otherView),
+                constraint(item: self, attribute: .bottom, toItem: otherView),
+                constraint(item: self, attribute: .left, toItem: otherView)
             ]
             spv.addConstraints(cs)
         }
@@ -157,9 +157,9 @@ public extension UIView {
      - Returns: Itself, enabling chaining,
      
      */
-    public func heightEqualsWidth() -> UIView {
+    @discardableResult public func heightEqualsWidth() -> UIView {
         if let spv = superview {
-            let c = constraint(item: self, attribute: .Height, toItem: self, attribute: .Width)
+            let c = constraint(item: self, attribute: .height, toItem: self, attribute: .width)
             spv.addConstraint(c)
         }
         return self

--- a/Stevia/Stevia/Stevia/Source/Stevia+Content.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Content.swift
@@ -17,8 +17,8 @@ public extension UIButton {
      
      - Returns: Itself for chaining purposes
     */
-    public func text(t: String) -> Self {
-        setTitle(t, forState: .Normal)
+    @discardableResult public func text(_ t: String) -> Self {
+        setTitle(t, for: UIControlState())
         return self
     }
     
@@ -30,7 +30,7 @@ public extension UIButton {
      
      - Returns: Itself for chaining purposes
      */
-    public func textKey(t: String) -> Self {
+    @discardableResult public func textKey(_ t: String) -> Self {
         text(NSLocalizedString(t, comment: ""))
         return self
     }
@@ -42,8 +42,8 @@ public extension UIButton {
      
      - Returns: Itself for chaining purposes
      */
-    public func image(s: String) -> Self {
-        setImage(UIImage(named:s), forState: .Normal)
+    @discardableResult public func image(_ s: String) -> Self {
+        setImage(UIImage(named:s), for: UIControlState())
         return self
     }
 }
@@ -54,7 +54,7 @@ public extension UITextField {
      Sets the textfield placeholder but in a chainable fashion
      - Returns: Itself for chaining purposes
      */
-    public func placeholder(t: String) -> Self {
+    @discardableResult public func placeholder(_ t: String) -> Self {
         placeholder = t
         return self
     }
@@ -65,7 +65,7 @@ public extension UILabel {
      Sets the label text but in a chainable fashion
      - Returns: Itself for chaining purposes
      */
-    public func text(t: String) -> Self {
+    @discardableResult public func text(_ t: String) -> Self {
         text = t
         return self
     }
@@ -75,7 +75,7 @@ public extension UILabel {
      Essentially a shortcut for `text = NSLocalizedString("X", comment: "")`
      - Returns: Itself for chaining purposes
      */
-    public func textKey(t: String) -> Self {
+    @discardableResult public func textKey(_ t: String) -> Self {
         text(NSLocalizedString(t, comment: ""))
         return self
     }
@@ -89,7 +89,7 @@ extension UIImageView {
      
      - Returns: Itself for chaining purposes
      */
-    public func image(t: String) -> Self {
+    @discardableResult public func image(_ t: String) -> Self {
         image = UIImage(named: t)
         return self
     }

--- a/Stevia/Stevia/Stevia/Source/Stevia+Fill.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Fill.swift
@@ -14,49 +14,49 @@ public extension UIView {
      Adds the constraints needed for the view to fill its `superview`.
      A padding can be used to apply equal spaces between the view and its superview
     */
-    public func fillContainer(padding: CGFloat = 0) {
+    @discardableResult public func fillContainer(_ padding: CGFloat = 0) {
         fillHorizontally(m: padding)
         fillVertically(m: padding)
     }
     
-    @available(*, deprecated=2.2.1, message="Use 'fillVertically' instead")
+    @available(*, deprecated: 2.2.1, message: "Use 'fillVertically' instead")
     /**
      Adds the constraints needed for the view to fill its `superview` Vertically.
      A padding can be used to apply equal spaces between the view and its superview
      */
     public func fillV(m points: CGFloat = 0) -> UIView {
-        return fill(.Vertical, points: points)
+        return fill(.vertical, points: points)
     }
     
     /**
      Adds the constraints needed for the view to fill its `superview` Vertically.
      A padding can be used to apply equal spaces between the view and its superview
      */
-    public func fillVertically(m points: CGFloat = 0) -> UIView {
-        return fill(.Vertical, points: points)
+    @discardableResult public func fillVertically(m points: CGFloat = 0) -> UIView {
+        return fill(.vertical, points: points)
     }
     
 
-    @available(*, deprecated=2.2.1, message="Use 'fillHorizontally' instead")
+    @available(*, deprecated: 2.2.1, message: "Use 'fillHorizontally' instead")
     /**
      Adds the constraints needed for the view to fill its `superview` Horizontally.
      A padding can be used to apply equal spaces between the view and its superview
      */
     public func fillH(m points: CGFloat = 0) -> UIView {
-        return fill(.Horizontal, points: points)
+        return fill(.horizontal, points: points)
     }
     
     /**
      Adds the constraints needed for the view to fill its `superview` Horizontally.
      A padding can be used to apply equal spaces between the view and its superview
      */
-    public func fillHorizontally(m points: CGFloat = 0) -> UIView {
-        return fill(.Horizontal, points: points)
+    @discardableResult public func fillHorizontally(m points: CGFloat = 0) -> UIView {
+        return fill(.horizontal, points: points)
     }
     
-    private func fill(axis: UILayoutConstraintAxis, points: CGFloat = 0) -> UIView {
-        let a: NSLayoutAttribute = axis == .Vertical ? .Top : .Left
-        let b: NSLayoutAttribute = axis == .Vertical ? .Bottom : .Right
+    private func fill(_ axis: UILayoutConstraintAxis, points: CGFloat = 0) -> UIView {
+        let a: NSLayoutAttribute = axis == .vertical ? .top : .left
+        let b: NSLayoutAttribute = axis == .vertical ? .bottom : .right
         if let spv = superview {
             let c1 = constraint(item: self, attribute: a, toItem: spv, constant: points)
             let c2 = constraint(item: self, attribute: b, toItem: spv, constant: -points)

--- a/Stevia/Stevia/Stevia/Source/Stevia+FlexibleMargin.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+FlexibleMargin.swift
@@ -10,12 +10,12 @@ import Foundation
 
 prefix operator >= {}
 public prefix func >= (p: CGFloat) -> SteviaFlexibleMargin {
-    return SteviaFlexibleMargin(points: p, relation: .GreaterThanOrEqual)
+    return SteviaFlexibleMargin(points: p, relation: .greaterThanOrEqual)
 }
 
 prefix operator <= {}
 public prefix func <= (p: CGFloat) -> SteviaFlexibleMargin {
-    return SteviaFlexibleMargin(points: p, relation: .LessThanOrEqual)
+    return SteviaFlexibleMargin(points: p, relation: .lessThanOrEqual)
 }
 
 public struct SteviaFlexibleMargin {
@@ -30,29 +30,31 @@ public struct PartialFlexibleConstraint {
     var views: [UIView]?
 }
 
-public func - (left: UIView, right: SteviaFlexibleMargin) -> PartialFlexibleConstraint {
+@discardableResult public func - (left: UIView,
+                                  right: SteviaFlexibleMargin) -> PartialFlexibleConstraint {
     return PartialFlexibleConstraint(fm: right, view1: left, views: nil)
 }
 
-public func - (left: [UIView], right: SteviaFlexibleMargin) -> PartialFlexibleConstraint {
+@discardableResult public func - (left: [UIView],
+                                  right: SteviaFlexibleMargin) -> PartialFlexibleConstraint {
     return PartialFlexibleConstraint(fm: right, view1: nil, views: left)
 }
 
-public func - (left: PartialFlexibleConstraint, right: UIView) -> [UIView] {
+@discardableResult public func - (left: PartialFlexibleConstraint, right: UIView) -> [UIView] {
     if let views = left.views {
         if let spv = right.superview {
-            let c = constraint(item: right, attribute: .Left,
-                               toItem: views.last, attribute: .Right,
-                               relatedBy:left.fm.relation,
+            let c = constraint(item: right, attribute: .left,
+                               relatedBy:left.fm.relation, toItem: views.last,
+                               attribute: .right,
                                constant: left.fm.points)
             spv.addConstraint(c)
         }
         return views + [right]
     } else {
         if let spv = right.superview {
-            let c = constraint(item: right, attribute: .Left,
-                               toItem: left.view1!, attribute: .Right,
-                               relatedBy:left.fm.relation,
+            let c = constraint(item: right, attribute: .left,
+                               relatedBy:left.fm.relation, toItem: left.view1!,
+                               attribute: .right,
                                constant: left.fm.points)
             spv.addConstraint(c)
         }
@@ -67,15 +69,15 @@ public struct SteviaLeftFlexibleMargin {
     let fm: SteviaFlexibleMargin
 }
 
-public prefix func |- (fm: SteviaFlexibleMargin) -> SteviaLeftFlexibleMargin {
+@discardableResult public prefix func |- (fm: SteviaFlexibleMargin) -> SteviaLeftFlexibleMargin {
     return SteviaLeftFlexibleMargin(fm: fm)
 }
 
-public func - (left: SteviaLeftFlexibleMargin, right: UIView) -> UIView {
+@discardableResult public func - (left: SteviaLeftFlexibleMargin, right: UIView) -> UIView {
     if let spv = right.superview {
-        let c = constraint(item: right, attribute: .Left,
-                           toItem: spv, attribute: .Left,
-                           relatedBy:left.fm.relation,
+        let c = constraint(item: right, attribute: .left,
+                           relatedBy:left.fm.relation, toItem: spv,
+                           attribute: .left,
                            constant: left.fm.points)
         spv.addConstraint(c)
     }
@@ -88,27 +90,27 @@ public struct SteviaRightFlexibleMargin {
     let fm: SteviaFlexibleMargin
 }
 
-public postfix func -| (fm: SteviaFlexibleMargin) -> SteviaRightFlexibleMargin {
+@discardableResult public postfix func -| (fm: SteviaFlexibleMargin) -> SteviaRightFlexibleMargin {
     return SteviaRightFlexibleMargin(fm: fm)
 }
 
-public func - (left: UIView, right: SteviaRightFlexibleMargin) -> UIView {
+@discardableResult public func - (left: UIView, right: SteviaRightFlexibleMargin) -> UIView {
     if let spv = left.superview {
-        let c = constraint(item: spv, attribute: .Right,
-                           toItem: left, attribute: .Right,
-                           relatedBy:right.fm.relation,
+        let c = constraint(item: spv, attribute: .right,
+                           relatedBy:right.fm.relation, toItem: left,
+                           attribute: .right,
                            constant: right.fm.points)
         spv.addConstraint(c)
     }
     return left
 }
 
-public func - (left: [UIView], right: SteviaRightFlexibleMargin) -> [UIView] {
+@discardableResult public func - (left: [UIView], right: SteviaRightFlexibleMargin) -> [UIView] {
     if let spv = left.last!.superview {
-        let c = constraint(item: spv, attribute: .Right,
-                           toItem: left.last!,
-                           attribute: .Right,
+        let c = constraint(item: spv, attribute: .right,
                            relatedBy:right.fm.relation,
+                           toItem: left.last!,
+                           attribute: .right,
                            constant: right.fm.points)
         spv.addConstraint(c)
     }

--- a/Stevia/Stevia/Stevia/Source/Stevia+GetConstraint.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+GetConstraint.swift
@@ -22,7 +22,7 @@ public extension UIView {
     - Returns: The left NSLayoutConstraint if found.
      */
     public var leftConstraint: NSLayoutConstraint? {
-        return constraintForView(self, attribute: .Left)
+        return constraintForView(self, attribute: .left)
     }
 
     /** Gets the right constraint if found.
@@ -38,7 +38,7 @@ public extension UIView {
     - Returns: The right NSLayoutConstraint if found.
      */
     public var rightConstraint: NSLayoutConstraint? {
-        return constraintForView(self, attribute: .Right)
+        return constraintForView(self, attribute: .right)
     }
     
     
@@ -55,7 +55,7 @@ public extension UIView {
     - Returns: The top NSLayoutConstraint if found.
      */
     public var topConstraint: NSLayoutConstraint? {
-        return constraintForView(self, attribute: .Top)
+        return constraintForView(self, attribute: .top)
     }
     
     /** Gets the bottom constraint if found.
@@ -71,7 +71,7 @@ public extension UIView {
      - Returns: The bottom NSLayoutConstraint if found.
      */
     public var bottomConstraint: NSLayoutConstraint? {
-        return constraintForView(self, attribute: .Bottom)
+        return constraintForView(self, attribute: .bottom)
     }
     
     /** Gets the height constraint if found.
@@ -87,7 +87,7 @@ public extension UIView {
     - Returns: The height NSLayoutConstraint if found.
     */
     public var heightConstraint: NSLayoutConstraint? {
-        return constraintForView(self, attribute: .Height)
+        return constraintForView(self, attribute: .height)
     }
     
     /** Gets the width constraint if found.
@@ -103,18 +103,18 @@ public extension UIView {
      - Returns: The width NSLayoutConstraint if found.
      */
     public var widthConstraint: NSLayoutConstraint? {
-        return constraintForView(self, attribute: .Width)
+        return constraintForView(self, attribute: .width)
     }
     
 }
 
-func constraintForView(v: UIView, attribute: NSLayoutAttribute) -> NSLayoutConstraint? {
+func constraintForView(_ v: UIView, attribute: NSLayoutAttribute) -> NSLayoutConstraint? {
     if let spv = v.superview {
         for c in spv.constraints {
-            if let fi = c.firstItem as? NSObject where fi == v && c.firstAttribute == attribute {
+            if let fi = c.firstItem as? NSObject, fi == v && c.firstAttribute == attribute {
                 return c
             }
-            if let si = c.secondItem as? NSObject where si == v && c.secondAttribute == attribute {
+            if let si = c.secondItem as? NSObject, si == v && c.secondAttribute == attribute {
                 return c
             }
         }

--- a/Stevia/Stevia/Stevia/Source/Stevia+Hierarchy.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Hierarchy.swift
@@ -42,7 +42,7 @@ public extension UIView {
      
      - Returns: Itself to enable nested layouts.
      */
-    public func sv(subViews: UIView...) -> UIView {
+    @discardableResult public func sv(_ subViews: UIView...) -> UIView {
         return sv(subViews)
     }
 
@@ -77,7 +77,7 @@ public extension UIView {
      
      - Returns: Itself to enable nested layouts.
      */
-    public func sv(subViews: [UIView]) -> UIView {
+    @discardableResult public func sv(_ subViews: [UIView]) -> UIView {
         for sv in subViews {
             addSubview(sv)
             sv.translatesAutoresizingMaskIntoConstraints = false
@@ -118,7 +118,7 @@ public extension UITableViewCell {
      
      - Returns: Itself to enable nested layouts.
      */
-    public override func sv(subViews: [UIView]) -> UIView {
+    @discardableResult public override func sv(_ subViews: [UIView]) -> UIView {
         return contentView.sv(subViews)
     }
 }
@@ -156,7 +156,7 @@ public extension UICollectionViewCell {
      
      - Returns: Itself to enable nested layouts.
      */
-    public override func sv(subViews: [UIView]) -> UIView {
+    @discardableResult public override func sv(_ subViews: [UIView]) -> UIView {
         return contentView.sv(subViews)
     }
 }

--- a/Stevia/Stevia/Stevia/Source/Stevia+Notifications.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Notifications.swift
@@ -10,8 +10,8 @@ import UIKit
 
 public extension NSObject {
     
-    public func on(event: String, _ callback:() -> Void) {
-        NSNotificationCenter.defaultCenter().addObserverForName(event,
+    public func on(_ event: String, _ callback:() -> Void) {
+        NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: event),
                                                                 object: nil,
                                                                 queue: nil) { _ in
             callback()

--- a/Stevia/Stevia/Stevia/Source/Stevia+Notifications.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Notifications.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public extension NSObject {
     
-    public func on(_ event: String, _ callback:() -> Void) {
+    public func on(_ event: String, _ callback:@escaping () -> Void) {
         NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: event),
                                                                 object: nil,
                                                                 queue: nil) { _ in

--- a/Stevia/Stevia/Stevia/Source/Stevia+Operators.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Operators.swift
@@ -9,57 +9,57 @@
 import UIKit
 
 prefix operator | {}
-public prefix func | (p: UIView) -> UIView {
+@discardableResult public prefix func | (p: UIView) -> UIView {
     return p.left(0)
 }
 
 postfix operator | {}
-public postfix func | (p: UIView) -> UIView {
+@discardableResult public postfix func | (p: UIView) -> UIView {
     return p.right(0)
 }
 
 
 infix operator ~ {}
 
-public func ~ (left: UIView, right: CGFloat) -> UIView {
+@discardableResult public func ~ (left: UIView, right: CGFloat) -> UIView {
     return left.height(right)
 }
 
-public func ~ (left: UIView, right: SteviaFlexibleMargin) -> UIView {
+@discardableResult public func ~ (left: UIView, right: SteviaFlexibleMargin) -> UIView {
     return left.height(right)
 }
 
-public func ~ (left: [UIView], right: CGFloat) -> [UIView] {
+@discardableResult public func ~ (left: [UIView], right: CGFloat) -> [UIView] {
     for l in left { l.height(right) }
     return left
 }
 
-public func ~ (left: [UIView], right: SteviaFlexibleMargin) -> [UIView] {
+@discardableResult public func ~ (left: [UIView], right: SteviaFlexibleMargin) -> [UIView] {
     for l in left { l.height(right) }
     return left
 }
 
 prefix operator |- {}
-public prefix func |- (p: CGFloat) -> SideConstraint {
+@discardableResult public prefix func |- (p: CGFloat) -> SideConstraint {
     var s = SideConstraint()
     s.constant = p
     return s
 }
 
-public prefix func |- (v: UIView) -> UIView {
+@discardableResult public prefix func |- (v: UIView) -> UIView {
     v.left(8)
     return v
 }
 
 
 postfix operator -| {}
-public postfix func -| (p: CGFloat) -> SideConstraint {
+@discardableResult public postfix func -| (p: CGFloat) -> SideConstraint {
     var s = SideConstraint()
     s.constant = p
     return s
 }
 
-public postfix func -| (v: UIView) -> UIView {
+@discardableResult public postfix func -| (v: UIView) -> UIView {
     v.right(8)
     return v
 }
@@ -75,7 +75,7 @@ public struct PartialConstraint {
     var views: [UIView]?
 }
 
-public func - (left: UIView, right: CGFloat) -> PartialConstraint {
+@discardableResult public func - (left: UIView, right: CGFloat) -> PartialConstraint {
     var p = PartialConstraint()
     p.view1 = left
     p.constant = right
@@ -84,10 +84,10 @@ public func - (left: UIView, right: CGFloat) -> PartialConstraint {
 
 // Side Constraints
 
-public func - (left: SideConstraint, right: UIView) -> UIView {
+@discardableResult public func - (left: SideConstraint, right: UIView) -> UIView {
     if let spv = right.superview {
-        let c = constraint(item: right, attribute: .Left,
-                           toItem: spv, attribute: .Left,
+        let c = constraint(item: right, attribute: .left,
+                           toItem: spv, attribute: .left,
                            constant: left.constant)
         spv.addConstraint(c)
     }
@@ -95,11 +95,11 @@ public func - (left: SideConstraint, right: UIView) -> UIView {
 }
 
 
-public func - (left: [UIView], right: SideConstraint) -> [UIView] {
+@discardableResult public func - (left: [UIView], right: SideConstraint) -> [UIView] {
     let lastView = left[left.count-1]
     if let spv = lastView.superview {
-        let c = constraint(item: lastView, attribute: .Right,
-                           toItem: spv, attribute: .Right,
+        let c = constraint(item: lastView, attribute: .right,
+                           toItem: spv, attribute: .right,
                            constant: -right.constant)
         spv.addConstraint(c)
     }
@@ -107,10 +107,10 @@ public func - (left: [UIView], right: SideConstraint) -> [UIView] {
 }
 
 
-public func - (left: UIView, right: SideConstraint) -> UIView {
+@discardableResult public func - (left: UIView, right: SideConstraint) -> UIView {
     if let spv = left.superview {
-        let c = constraint(item: left, attribute: .Right,
-                           toItem: spv, attribute: .Right,
+        let c = constraint(item: left, attribute: .right,
+                           toItem: spv, attribute: .right,
                            constant: -right.constant)
         spv.addConstraint(c)
     }
@@ -118,12 +118,12 @@ public func - (left: UIView, right: SideConstraint) -> UIView {
 }
 
 
-public func - (left: PartialConstraint, right: UIView) -> [UIView] {
+@discardableResult public func - (left: PartialConstraint, right: UIView) -> [UIView] {
     if let views = left.views {
         if let spv = right.superview {
             let lastView = views[views.count-1]
-            let c = constraint(item: lastView, attribute: .Right,
-                               toItem: right, attribute: .Left,
+            let c = constraint(item: lastView, attribute: .right,
+                               toItem: right, attribute: .left,
                                constant: -left.constant)
             spv.addConstraint(c)
         }
@@ -132,8 +132,8 @@ public func - (left: PartialConstraint, right: UIView) -> [UIView] {
     } else {
         // were at the end?? nooope?/?
         if let spv = right.superview {
-            let c = constraint(item: left.view1, attribute: .Right,
-                               toItem: right, attribute: .Left,
+            let c = constraint(item: left.view1, attribute: .right,
+                               toItem: right, attribute: .left,
                                constant: -left.constant)
             spv.addConstraint(c)
         }
@@ -141,28 +141,28 @@ public func - (left: PartialConstraint, right: UIView) -> [UIView] {
     }
 }
 
-public func - (left: UIView, right: UIView) -> [UIView] {
+@discardableResult public func - (left: UIView, right: UIView) -> [UIView] {
     if let spv = left.superview {
-        let c = constraint(item: right, attribute: .Left,
-                           toItem: left, attribute: .Right,
+        let c = constraint(item: right, attribute: .left,
+                           toItem: left, attribute: .right,
                            constant: 8)
         spv.addConstraint(c)
     }
     return [left, right]
 }
 
-public func - (left: [UIView], right: CGFloat) -> PartialConstraint {
+@discardableResult public func - (left: [UIView], right: CGFloat) -> PartialConstraint {
     var p = PartialConstraint()
     p.constant = right
     p.views = left
     return p
 }
 
-public func - (left: [UIView], right: UIView) -> [UIView] {
+@discardableResult public func - (left: [UIView], right: UIView) -> [UIView] {
     let lastView = left[left.count-1]
     if let spv = lastView.superview {
-        let c = constraint(item: lastView, attribute: .Right,
-                           toItem: right, attribute: .Left,
+        let c = constraint(item: lastView, attribute: .right,
+                           toItem: right, attribute: .left,
                            constant: -8)
         spv.addConstraint(c)
     }
@@ -175,16 +175,16 @@ public struct Space {
     var previousViews: [UIView]!
 }
 
-public func - (left: UIView, right: String) -> Space {
+@discardableResult public func - (left: UIView, right: String) -> Space {
     return Space(previousViews: [left])
 }
 
-public func - (left: [UIView], right: String) -> Space {
+@discardableResult public func - (left: [UIView], right: String) -> Space {
     return Space(previousViews: left)
 }
 
-public func - (left: Space, right: UIView) -> [UIView] {
+@discardableResult public func - (left: Space, right: UIView) -> [UIView] {
     var va = left.previousViews
-    va.append(right)
-    return va
+    va?.append(right)
+    return va ?? []
 }

--- a/Stevia/Stevia/Stevia/Source/Stevia+Position.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Position.swift
@@ -20,8 +20,8 @@ public extension UIView {
      
     - Returns: Itself for chaining purposes
     */
-    public func left(points: CGFloat) -> UIView {
-        return position(.Left, points: points)
+    @discardableResult public func left(_ points: CGFloat) -> UIView {
+        return position(.left, points: points)
     }
     
     /** Sets the right margin for a view.
@@ -34,8 +34,8 @@ public extension UIView {
      
     - Returns: Itself for chaining purposes
     */
-    public func right(points: CGFloat) -> UIView {
-        return position(.Right, points: -points)
+    @discardableResult public func right(_ points: CGFloat) -> UIView {
+        return position(.right, points: -points)
     }
     
     /** Sets the top margin for a view.
@@ -48,8 +48,8 @@ public extension UIView {
      
     - Returns: Itself for chaining purposes
     */
-    public func top(points: CGFloat) -> UIView {
-        return position(.Top, points: points)
+    @discardableResult public func top(_ points: CGFloat) -> UIView {
+        return position(.top, points: points)
     }
     
     /** Sets the bottom margin for a view.
@@ -62,8 +62,8 @@ public extension UIView {
      
     - Returns: Itself for chaining purposes
     */
-    public func bottom(points: CGFloat) -> UIView {
-        return position(.Bottom, points: -points)
+    @discardableResult public func bottom(_ points: CGFloat) -> UIView {
+        return position(.bottom, points: -points)
     }
 
     /** Sets the left margin for a view.
@@ -76,8 +76,8 @@ public extension UIView {
      
     - Returns: Itself for chaining purposes
     */
-    public func left(fm: SteviaFlexibleMargin) -> UIView {
-        return position(.Left, relatedBy:fm.relation, points: fm.points)
+    @discardableResult public func left(_ fm: SteviaFlexibleMargin) -> UIView {
+        return position(.left, relatedBy:fm.relation, points: fm.points)
     }
     
     /** Sets the right margin for a view.
@@ -90,17 +90,17 @@ public extension UIView {
      
     - Returns: Itself for chaining purposes
     */
-    public func right(fm: SteviaFlexibleMargin) -> UIView {
+    @discardableResult public func right(_ fm: SteviaFlexibleMargin) -> UIView {
         // For right this should be inverted.
         var n = SteviaFlexibleMargin()
         n.points = -fm.points
-        if fm.relation == .GreaterThanOrEqual {
-            n.relation = .LessThanOrEqual
+        if fm.relation == .greaterThanOrEqual {
+            n.relation = .lessThanOrEqual
         }
-        if fm.relation == .LessThanOrEqual {
-            n.relation = .GreaterThanOrEqual
+        if fm.relation == .lessThanOrEqual {
+            n.relation = .greaterThanOrEqual
         }
-        return position(.Right, relatedBy:n.relation, points: n.points)
+        return position(.right, relatedBy:n.relation, points: n.points)
     }
     
     /** Sets the top margin for a view.
@@ -113,8 +113,8 @@ public extension UIView {
      
     - Returns: Itself for chaining purposes
     */
-    public func top(fm: SteviaFlexibleMargin) -> UIView {
-        return position(.Top, relatedBy:fm.relation, points: fm.points)
+    @discardableResult public func top(_ fm: SteviaFlexibleMargin) -> UIView {
+        return position(.top, relatedBy:fm.relation, points: fm.points)
     }
     
     /** Sets the bottom margin for a view.
@@ -127,26 +127,26 @@ public extension UIView {
      
     - Returns: Itself for chaining purposes
     */
-    public func bottom(fm: SteviaFlexibleMargin) -> UIView {
+    @discardableResult public func bottom(_ fm: SteviaFlexibleMargin) -> UIView {
         // For bottom this should be inverted.
         var n = SteviaFlexibleMargin()
         n.points = -fm.points
-        if fm.relation == .GreaterThanOrEqual {
-            n.relation = .LessThanOrEqual
+        if fm.relation == .greaterThanOrEqual {
+            n.relation = .lessThanOrEqual
         }
-        if fm.relation == .LessThanOrEqual {
-            n.relation = .GreaterThanOrEqual
+        if fm.relation == .lessThanOrEqual {
+            n.relation = .greaterThanOrEqual
         }
-        return position(.Bottom, relatedBy:n.relation, points: n.points)
+        return position(.bottom, relatedBy:n.relation, points: n.points)
     }
     
-    private func position(position: NSLayoutAttribute,
-                          relatedBy: NSLayoutRelation = .Equal,
+    private func position(_ position: NSLayoutAttribute,
+                          relatedBy: NSLayoutRelation = .equal,
                           points: CGFloat) -> UIView {
         if let spv = superview {
             let c = constraint(item: self, attribute: position,
-                               toItem: spv,
                                relatedBy:relatedBy,
+                               toItem: spv,
                                constant: points)
             spv.addConstraint(c)
         }

--- a/Stevia/Stevia/Stevia/Source/Stevia+Size.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Size.swift
@@ -24,7 +24,7 @@ public extension UIView {
      - Returns: Itself, enabling chaining,
      
      */
-    public func size(points: CGFloat) -> UIView {
+    @discardableResult public func size(_ points: CGFloat) -> UIView {
         width(points)
         height(points)
         return self
@@ -49,8 +49,8 @@ public extension UIView {
      - Returns: Itself, enabling chaining,
      
      */
-    public func height(points: CGFloat) -> UIView {
-        return size(.Height, points: points)
+    @discardableResult public func height(_ points: CGFloat) -> UIView {
+        return size(.height, points: points)
     }
     
     /**
@@ -65,8 +65,8 @@ public extension UIView {
      - Returns: Itself, enabling chaining,
      
      */
-    public func width(points: CGFloat) -> UIView {
-        return size(.Width, points: points)
+    @discardableResult public func width(_ points: CGFloat) -> UIView {
+        return size(.width, points: points)
     }
     
     /**
@@ -87,8 +87,8 @@ public extension UIView {
      - Returns: Itself, enabling chaining,
      
      */
-    public func height(fm: SteviaFlexibleMargin) -> UIView {
-        return size(.Height, relatedBy: fm.relation, points: fm.points)
+    @discardableResult public func height(_ fm: SteviaFlexibleMargin) -> UIView {
+        return size(.height, relatedBy: fm.relation, points: fm.points)
     }
     
     /**
@@ -103,12 +103,12 @@ public extension UIView {
      - Returns: Itself, enabling chaining,
      
      */
-    public func width(fm: SteviaFlexibleMargin) -> UIView {
-        return size(.Width, relatedBy: fm.relation, points: fm.points)
+    @discardableResult public func width(_ fm: SteviaFlexibleMargin) -> UIView {
+        return size(.width, relatedBy: fm.relation, points: fm.points)
     }
     
-    private func size(attribute: NSLayoutAttribute,
-                      relatedBy: NSLayoutRelation = .Equal,
+    private func size(_ attribute: NSLayoutAttribute,
+                      relatedBy: NSLayoutRelation = .equal,
                       points: CGFloat) -> UIView {
         if let spv = superview {
             let c = constraint(item: self, attribute:attribute,
@@ -130,7 +130,7 @@ public extension UIView {
  - Returns: The views enabling chaining.
  
  */
-public func equalSizes(views: UIView...) -> [UIView] {
+@discardableResult public func equalSizes(_ views: UIView...) -> [UIView] {
     return equalSizes(views)
 }
 
@@ -144,7 +144,7 @@ public func equalSizes(views: UIView...) -> [UIView] {
  - Returns: The views enabling chaining.
  
  */
-public func equalSizes(views: [UIView]) -> [UIView] {
+@discardableResult public func equalSizes(_ views: [UIView]) -> [UIView] {
     equalHeights(views)
     equalWidths(views)
     return views
@@ -160,7 +160,7 @@ public func equalSizes(views: [UIView]) -> [UIView] {
  - Returns: The views enabling chaining.
  
  */
-public func equalWidths(views: UIView...) -> [UIView] {
+@discardableResult public func equalWidths(_ views: UIView...) -> [UIView] {
     return equalWidths(views)
 }
 
@@ -174,8 +174,8 @@ public func equalWidths(views: UIView...) -> [UIView] {
  - Returns: The views enabling chaining.
  
  */
-public func equalWidths(views: [UIView]) -> [UIView] {
-    equal(.Width, views: views)
+@discardableResult public func equalWidths(_ views: [UIView]) -> [UIView] {
+    equal(.width, views: views)
     return views
 }
 
@@ -189,7 +189,7 @@ public func equalWidths(views: [UIView]) -> [UIView] {
  - Returns: The views enabling chaining.
  
  */
-public func equalHeights(views: UIView...) -> [UIView] {
+@discardableResult public func equalHeights(_ views: UIView...) -> [UIView] {
     return equalHeights(views)
 }
 
@@ -203,12 +203,12 @@ public func equalHeights(views: UIView...) -> [UIView] {
  - Returns: The views enabling chaining.
  
  */
-public func equalHeights(views: [UIView]) -> [UIView] {
-    equal(.Height, views: views)
+@discardableResult public func equalHeights(_ views: [UIView]) -> [UIView] {
+    equal(.height, views: views)
     return views
 }
 
-private func equal(attribute: NSLayoutAttribute, views: [UIView]) {
+private func equal(_ attribute: NSLayoutAttribute, views: [UIView]) {
     var previousView: UIView?
     for v in views {
         if let pv = previousView {

--- a/Stevia/Stevia/Stevia/Source/Stevia+Stacks.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Stacks.swift
@@ -31,14 +31,14 @@ public extension UIView {
      )
      ```
      */
-    public func layout(objects: Any...) -> [UIView] {
+    @discardableResult public func layout(_ objects: Any...) -> [UIView] {
         return stackV(objects)
     }
     
-    private func stackV(objects: [Any]) -> [UIView] {
+    private func stackV(_ objects: [Any]) -> [UIView] {
         var previousMargin: CGFloat? = nil
         var previousFlexibleMargin: SteviaFlexibleMargin? = nil
-        for (i, o) in objects.enumerate() {
+        for (i, o) in objects.enumerated() {
             
             switch o {
             case let v as UIView:
@@ -59,16 +59,16 @@ public extension UIView {
                     } else {
                         if let vx = objects[i-2] as? UIView {
                             addConstraint(
-                                item: v, attribute: .Top,
+                                item: v, attribute: .top,
                                 relatedBy: pfm.relation,
-                                toItem: vx, attribute: .Bottom,
+                                toItem: vx, attribute: .bottom,
                                 multiplier: 1, constant: pfm.points
                             )
                         } else if let va = objects[i-2] as? [UIView] {
                             addConstraint(
-                                item: v, attribute: .Top,
+                                item: v, attribute: .top,
                                 relatedBy: pfm.relation,
-                                toItem: va.first!, attribute: .Bottom,
+                                toItem: va.first!, attribute: .bottom,
                                 multiplier: 1, constant: pfm.points
                             )
                         }
@@ -121,16 +121,16 @@ public extension UIView {
                 } else {
                     if let vx = objects[i-2] as? UIView {
                         addConstraint(
-                            item: v, attribute: .Top,
+                            item: v, attribute: .top,
                             relatedBy: pfm.relation,
-                            toItem: vx, attribute: .Bottom,
+                            toItem: vx, attribute: .bottom,
                             multiplier: 1, constant: pfm.points
                         )
                     } else if let va = objects[i-2] as? [UIView] {
                         addConstraint(
-                            item: v, attribute: .Top,
+                            item: v, attribute: .top,
                             relatedBy: pfm.relation,
-                            toItem: va.first!, attribute: .Bottom,
+                            toItem: va.first!, attribute: .bottom,
                             multiplier: 1, constant: pfm.points
                         )
                     }
@@ -145,7 +145,7 @@ public extension UIView {
         return objects.map {$0 as? UIView }.flatMap {$0}
     }
     
-    private func cgFloatMarginFromObject(o: Any) -> CGFloat {
+    private func cgFloatMarginFromObject(_ o: Any) -> CGFloat {
         var m: CGFloat = 0
         if let i = o as? Int {
             m = CGFloat(i)
@@ -157,13 +157,14 @@ public extension UIView {
         return m
     }
     
-    private func tryStackViewVerticallyWithPreviousView(view: UIView, index: Int, objects: [Any]) {
+    private func tryStackViewVerticallyWithPreviousView(_ view: UIView,
+                                                        index: Int, objects: [Any]) {
         if let pv = previousViewFromIndex(index, objects: objects) {
             pv.stackV(v: view)
         }
     }
     
-    private func previousViewFromIndex(index: Int, objects: [Any]) -> UIView? {
+    private func previousViewFromIndex(_ index: Int, objects: [Any]) -> UIView? {
         if index != 0 {
             if let previousView = objects[index-1] as? UIView {
                 return previousView
@@ -172,13 +173,13 @@ public extension UIView {
         return nil
     }
     
-    private func stackV(m points: CGFloat = 0, v: UIView) -> UIView {
-        return stack(.Vertical, points: points, v: v)
+    @discardableResult private func stackV(m points: CGFloat = 0, v: UIView) -> UIView {
+        return stack(.vertical, points: points, v: v)
     }
     
-    private func stack(axis: UILayoutConstraintAxis, points: CGFloat = 0, v: UIView) -> UIView {
-        let a: NSLayoutAttribute = axis == .Vertical ? .Top : .Left
-        let b: NSLayoutAttribute = axis == .Vertical ? .Bottom : .Right
+    private func stack(_ axis: UILayoutConstraintAxis, points: CGFloat = 0, v: UIView) -> UIView {
+        let a: NSLayoutAttribute = axis == .vertical ? .top : .left
+        let b: NSLayoutAttribute = axis == .vertical ? .bottom : .right
         if let spv = superview {
             let c = constraint(item: v, attribute: a, toItem: self, attribute: b, constant:points)
             spv.addConstraint(c)

--- a/Stevia/Stevia/Stevia/Source/Stevia+Style.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Style.swift
@@ -35,7 +35,7 @@ public extension UIAppearance {
     - Returns: Itself for chaining purposes
      
      */
-    public func style(styleClosure: (Self)->()) -> Self {
+    @discardableResult public func style(_ styleClosure: (Self)->()) -> Self {
         styleClosure(self)
         return self
     }

--- a/Stevia/Stevia/Stevia/Source/Stevia+Tap.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Tap.swift
@@ -61,9 +61,9 @@ public extension UIButton {
      - Returns: Itself for chaining purposes
      
      */
-    public func tap(block:() -> Void) -> UIButton {
+    public func tap(_ block:() -> Void) -> UIButton {
         #if swift(>=2.2)
-        addTarget(self, action: #selector(UIButton.tapped), forControlEvents: .TouchUpInside)
+        addTarget(self, action: #selector(UIButton.tapped), for: .touchUpInside)
         #else
         addTarget(self, action: "tapped", forControlEvents: .TouchUpInside)
         #endif

--- a/Stevia/Stevia/Stevia/Source/Stevia+Tap.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Tap.swift
@@ -61,7 +61,7 @@ public extension UIButton {
      - Returns: Itself for chaining purposes
      
      */
-    public func tap(_ block:() -> Void) -> UIButton {
+    public func tap(_ block: @escaping () -> Void) -> UIButton {
         #if swift(>=2.2)
         addTarget(self, action: #selector(UIButton.tapped), for: .touchUpInside)
         #else

--- a/Stevia/Stevia/SteviaTests/CenterTests.swift
+++ b/Stevia/Stevia/SteviaTests/CenterTests.swift
@@ -16,7 +16,7 @@ class CenterTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        win = UIWindow(frame: UIScreen.mainScreen().bounds)
+        win = UIWindow(frame: UIScreen.main.bounds)
         ctrler =  UIViewController()
         win.rootViewController = ctrler
         v = UIView()
@@ -30,14 +30,14 @@ class CenterTests: XCTestCase {
     
     func testCenterHorizontally() {
         v.size(100)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.height, 100, accuracy: CGFloat(FLT_EPSILON))
         v.centerHorizontally()
-        v.setNeedsLayout()
-        v.layoutIfNeeded()
+        ctrler.view.setNeedsLayout()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x,
                                    ctrler.view.frame.width/2.0 - (v.frame.width/2.0),
@@ -48,14 +48,14 @@ class CenterTests: XCTestCase {
     
     func testCenterHorizontallyWithOffset() {
         v.size(100)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.height, 100, accuracy: CGFloat(FLT_EPSILON))
         v.centerHorizontally(50)
-        v.setNeedsLayout()
-        v.layoutIfNeeded()
+        ctrler.view.setNeedsLayout()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x - 50,
                                    ctrler.view.frame.width/2.0 - (v.frame.width/2.0),
@@ -67,14 +67,14 @@ class CenterTests: XCTestCase {
     
     func testCenterVertically() {
         v.size(100)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.height, 100, accuracy: CGFloat(FLT_EPSILON))
         v.centerVertically()
-        v.setNeedsLayout()
-        v.layoutIfNeeded()
+        ctrler.view.setNeedsLayout()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y,
                                    ctrler.view.frame.height/2.0 - (v.frame.height/2.0),
                                    accuracy: CGFloat(FLT_EPSILON))
@@ -85,14 +85,14 @@ class CenterTests: XCTestCase {
     
     func testCenterVerticallyWithOffset() {
         v.size(100)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.height, 100, accuracy: CGFloat(FLT_EPSILON))
         v.centerVertically(50)
-        v.setNeedsLayout()
-        v.layoutIfNeeded()
+        ctrler.view.setNeedsLayout()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y - 50,
                                    ctrler.view.frame.height/2.0 - (v.frame.height/2.0),
                                    accuracy: CGFloat(FLT_EPSILON))
@@ -103,14 +103,14 @@ class CenterTests: XCTestCase {
     
     func testCenterInContainer() {
         v.size(100)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.height, 100, accuracy: CGFloat(FLT_EPSILON))
         v.centerInContainer()
-        v.setNeedsLayout()
-        v.layoutIfNeeded()
+        ctrler.view.setNeedsLayout()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y,
                                    ctrler.view.frame.height/2.0 - (v.frame.height/2.0),
                                    accuracy: CGFloat(FLT_EPSILON))

--- a/Stevia/Stevia/SteviaTests/ContentTests.swift
+++ b/Stevia/Stevia/SteviaTests/ContentTests.swift
@@ -27,7 +27,7 @@ class UIButtonContentTests: XCTestCase {
     func testText() {
         button.text(title)
         XCTAssertEqual(button.currentTitle, title)
-        XCTAssertEqual(button.state, UIControlState.Normal)
+        XCTAssertEqual(button.state, .normal)
     }
     
     func testTextKey() {

--- a/Stevia/Stevia/SteviaTests/FillTests.swift
+++ b/Stevia/Stevia/SteviaTests/FillTests.swift
@@ -16,7 +16,7 @@ class FillTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        win = UIWindow(frame: UIScreen.mainScreen().bounds)
+        win = UIWindow(frame: UIScreen.main.bounds)
         ctrler =  UIViewController()
         win.rootViewController = ctrler
     }
@@ -29,8 +29,7 @@ class FillTests: XCTestCase {
         let b = UIButton()
         ctrler.view.sv(b)
         b.fillContainer()
-        b.layoutIfNeeded() // This is needed to force auto-layout to kick-in
-        
+        ctrler.view.layoutIfNeeded() // This is needed to force auto-layout to kick-in
         XCTAssertEqual(ctrler.view.frame, b.frame)
 
     }

--- a/Stevia/Stevia/SteviaTests/FlexibleMarginTests.swift
+++ b/Stevia/Stevia/SteviaTests/FlexibleMarginTests.swift
@@ -17,7 +17,7 @@ class FlexibleMarginTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        win = UIWindow(frame: UIScreen.mainScreen().bounds)
+        win = UIWindow(frame: UIScreen.main.bounds)
         ctrler =  UIViewController()
         win.rootViewController = ctrler
         v = UIView()
@@ -33,7 +33,7 @@ class FlexibleMarginTests: XCTestCase {
     
     func testGreaterTop() {
         v.top(>=23)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 23, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
@@ -42,7 +42,7 @@ class FlexibleMarginTests: XCTestCase {
     
     func testGreaterBottom() {
         v.bottom(>=45)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, ctrler.view.frame.height - v.frame.height - 45,
                                    accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
@@ -52,7 +52,7 @@ class FlexibleMarginTests: XCTestCase {
     
     func testGreaterLeft() {
         v.left(>=23)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 23, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
@@ -61,7 +61,7 @@ class FlexibleMarginTests: XCTestCase {
 
     func testGreaterRight() {
         v.right(>=74)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, ctrler.view.frame.width - v.frame.width - 74,
                                    accuracy: CGFloat(FLT_EPSILON))
@@ -71,7 +71,7 @@ class FlexibleMarginTests: XCTestCase {
     
     func testLessTop() {
         v.top(<=23)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 23, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         
@@ -81,7 +81,7 @@ class FlexibleMarginTests: XCTestCase {
     
     func testLessBottom() {
         v.bottom(<=45)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y,
                                    ctrler.view.frame.height - v.frame.height - 45,
                                    accuracy: CGFloat(FLT_EPSILON))
@@ -92,7 +92,7 @@ class FlexibleMarginTests: XCTestCase {
     
     func testLessLeft() {
         v.left(<=23)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 23, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
@@ -101,7 +101,7 @@ class FlexibleMarginTests: XCTestCase {
     
     func testLessLeftOperator() {
         |-(<=23)-v
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 23, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
@@ -110,7 +110,7 @@ class FlexibleMarginTests: XCTestCase {
     
     func testLessRight() {
         v.right(<=74)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, ctrler.view.frame.width - v.frame.width - 74,
                                    accuracy: CGFloat(FLT_EPSILON))
@@ -121,7 +121,7 @@ class FlexibleMarginTests: XCTestCase {
     
     func testLessRightOperator() {
         v-(<=74)-|
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, ctrler.view.frame.width - v.frame.width - 74,
                                    accuracy: CGFloat(FLT_EPSILON))

--- a/Stevia/Stevia/SteviaTests/FullLayoutTests.swift
+++ b/Stevia/Stevia/SteviaTests/FullLayoutTests.swift
@@ -44,7 +44,7 @@ class FullLayoutTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        win = UIWindow(frame: UIScreen.mainScreen().bounds)
+        win = UIWindow(frame: UIScreen.main.bounds)
         vc = UIViewController()///TestVC()
         win.rootViewController = vc
         v = TestView()

--- a/Stevia/Stevia/SteviaTests/LayoutTests.swift
+++ b/Stevia/Stevia/SteviaTests/LayoutTests.swift
@@ -17,7 +17,7 @@ class LayoutTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        win = UIWindow(frame: UIScreen.mainScreen().bounds)
+        win = UIWindow(frame: UIScreen.main.bounds)
         ctrler =  UIViewController()
         win.rootViewController = ctrler
         v = UIView()
@@ -31,9 +31,9 @@ class LayoutTests: XCTestCase {
     
     func testEmptyLeftMargin() {
         |v
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
-        XCTAssertEqualWithAccuracy(v.frame.origin.x,  0, accuracy: CGFloat(FLT_EPSILON))
+        XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.height, 0, accuracy: CGFloat(FLT_EPSILON))
         
@@ -41,7 +41,7 @@ class LayoutTests: XCTestCase {
     
     func testDefaultMargin() {
         |-v
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 8, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 0, accuracy: CGFloat(FLT_EPSILON))
@@ -50,7 +50,7 @@ class LayoutTests: XCTestCase {
     
     func testLeftMargin() {
         |-75-v
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 75, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 0, accuracy: CGFloat(FLT_EPSILON))
@@ -60,7 +60,7 @@ class LayoutTests: XCTestCase {
     
     func testEmptyRightMargin() {
         v|
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, ctrler.view.frame.width - v.frame.width,
                                    accuracy: CGFloat(FLT_EPSILON))
@@ -70,7 +70,7 @@ class LayoutTests: XCTestCase {
     
     func testDefaultRightMargin() {
         v-|
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, ctrler.view.frame.width - v.frame.width - 8,
                                    accuracy: CGFloat(FLT_EPSILON))
@@ -81,7 +81,7 @@ class LayoutTests: XCTestCase {
     
     func testRightMargin() {
         v-14-|
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, ctrler.view.frame.width - v.frame.width - 14,
                                    accuracy: CGFloat(FLT_EPSILON))
@@ -92,7 +92,7 @@ class LayoutTests: XCTestCase {
 
     func testHeight() {
         v ~ 180
-        v.layoutIfNeeded() // This is needed to force auto-layout to kick-in
+        ctrler.view.layoutIfNeeded() // This is needed to force auto-layout to kick-in
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 0, accuracy: CGFloat(FLT_EPSILON))
@@ -217,7 +217,9 @@ class LayoutTests: XCTestCase {
             XCTAssertEqualWithAccuracy(view.frame.height, 0, accuracy: CGFloat(FLT_EPSILON))
         }
         
-        |v1.width(20)-v2.width(20)-v3
+//        |v1.width(20)-v2.width(20)-v3 // Todo this donesn't work anymore :/ ??
+        |v1.width(20)-v2.width(20)-8-v3
+        
         ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v1.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v1.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))

--- a/Stevia/Stevia/SteviaTests/PositionTests.swift
+++ b/Stevia/Stevia/SteviaTests/PositionTests.swift
@@ -16,7 +16,7 @@ class PositionTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        win = UIWindow(frame: UIScreen.mainScreen().bounds)
+        win = UIWindow(frame: UIScreen.main.bounds)
         ctrler =  UIViewController()
         win.rootViewController = ctrler
         v = UIView()
@@ -30,7 +30,7 @@ class PositionTests: XCTestCase {
     
     func testTop() {
         v.top(23)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 23, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
@@ -39,7 +39,7 @@ class PositionTests: XCTestCase {
     
     func testBottom() {
         v.bottom(45)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, ctrler.view.frame.height - v.frame.height - 45,
                                    accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
@@ -50,7 +50,7 @@ class PositionTests: XCTestCase {
     
     func testLeft() {
         v.left(12)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.origin.x, 12, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
@@ -59,9 +59,9 @@ class PositionTests: XCTestCase {
     
     func testRight() {
         v.right(74)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
-        XCTAssertEqualWithAccuracy(v.frame.origin.x,  ctrler.view.frame.width - v.frame.width - 74,
+        XCTAssertEqualWithAccuracy(v.frame.origin.x, ctrler.view.frame.width - v.frame.width - 74,
                                    accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 100, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.height, 100, accuracy: CGFloat(FLT_EPSILON))

--- a/Stevia/Stevia/SteviaTests/SizeTests.swift
+++ b/Stevia/Stevia/SteviaTests/SizeTests.swift
@@ -17,7 +17,7 @@ class SizeTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        win = UIWindow(frame: UIScreen.mainScreen().bounds)
+        win = UIWindow(frame: UIScreen.main.bounds)
         ctrler =  UIViewController()
         win.rootViewController = ctrler
         v = UIView()
@@ -30,9 +30,9 @@ class SizeTests: XCTestCase {
     
     func testSize() {
         v.size(57)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
-        XCTAssertEqualWithAccuracy(v.frame.origin.x,  0, accuracy: CGFloat(FLT_EPSILON))
+        XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 57, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.height, 57, accuracy: CGFloat(FLT_EPSILON))
     }
@@ -40,9 +40,9 @@ class SizeTests: XCTestCase {
     func testWidthAndHeight() {
         v.width(36)
         v.height(23)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
-        XCTAssertEqualWithAccuracy(v.frame.origin.x,  0, accuracy: CGFloat(FLT_EPSILON))
+        XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 36, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.height, 23, accuracy: CGFloat(FLT_EPSILON))
     }
@@ -94,14 +94,14 @@ class SizeTests: XCTestCase {
         ctrler.view.layoutIfNeeded()
         
         XCTAssertEqualWithAccuracy(v1.frame.origin.y, 10, accuracy: CGFloat(FLT_EPSILON))
-        XCTAssertEqualWithAccuracy(v1.frame.origin.x,  20, accuracy: CGFloat(FLT_EPSILON))
+        XCTAssertEqualWithAccuracy(v1.frame.origin.x, 20, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v1.frame.width, ctrler.view.frame.width - 20,
                                    accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v1.frame.height, 32, accuracy: CGFloat(FLT_EPSILON))
         
         
         XCTAssertEqualWithAccuracy(v2.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
-        XCTAssertEqualWithAccuracy(v2.frame.origin.x,  0, accuracy: CGFloat(FLT_EPSILON))
+        XCTAssertEqualWithAccuracy(v2.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v2.frame.width, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v2.frame.height, 0, accuracy: CGFloat(FLT_EPSILON))
         
@@ -118,22 +118,20 @@ class SizeTests: XCTestCase {
     
     func testHeightEqualWidth() {
         v.heightEqualsWidth().width(85)
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
-        XCTAssertEqualWithAccuracy(v.frame.origin.x,  0, accuracy: CGFloat(FLT_EPSILON))
+        XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 85, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.height, 85, accuracy: CGFloat(FLT_EPSILON))
-
     }
 
     func testWidthEqualHeight() {
         v.height(192)
         v.heightEqualsWidth()
-        v.layoutIfNeeded()
+        ctrler.view.layoutIfNeeded()
         XCTAssertEqualWithAccuracy(v.frame.origin.y, 0, accuracy: CGFloat(FLT_EPSILON))
-        XCTAssertEqualWithAccuracy(v.frame.origin.x,  0, accuracy: CGFloat(FLT_EPSILON))
+        XCTAssertEqualWithAccuracy(v.frame.origin.x, 0, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.width, 192, accuracy: CGFloat(FLT_EPSILON))
         XCTAssertEqualWithAccuracy(v.frame.height, 192, accuracy: CGFloat(FLT_EPSILON))
-        
     }
 }

--- a/Stevia/Stevia/SteviaTests/StyleTests.swift
+++ b/Stevia/Stevia/SteviaTests/StyleTests.swift
@@ -12,11 +12,11 @@ import Stevia
 class StyleTests: XCTestCase {
 
     func styleView(view: UIView) {
-        view.backgroundColor = UIColor.yellowColor()
+        view.backgroundColor = .yellow
     }
     
     func styleLabel(label: UILabel) {
-        label.textColor = UIColor.yellowColor()
+        label.textColor = .yellow
     }
 
     func testStyle() {
@@ -28,14 +28,14 @@ class StyleTests: XCTestCase {
         let view: UIView = label
         view.style(styleView)
         
-        XCTAssertEqual(view.backgroundColor, UIColor.yellowColor())
-        XCTAssertEqual(label.textColor, UIColor.yellowColor())
+        XCTAssertEqual(view.backgroundColor, .yellow)
+        XCTAssertEqual(label.textColor, .yellow)
         
         //check type deduction
         label.style { (label) -> () in
-            label.textColor = UIColor.blueColor()
+            label.textColor = .blue
         }
-        XCTAssertEqual(label.textColor, UIColor.blueColor())
+        XCTAssertEqual(label.textColor, .blue)
     }
 
 


### PR DESCRIPTION
Fixes this problem: Cannot assign value of type '() -> Void' to type '(() -> Void)!'
Ref:
https://github.com/apple/swift-evolution/blob/master/proposals/0103-make-noescape-default.md
http://stackoverflow.com/questions/39002126/cannot-assign-value-of-type-void-to-type-void
