### PR TITLE
Make size work on orphan views

### DIFF
--- a/Source/Stevia+Size.swift
+++ b/Source/Stevia+Size.swift
@@ -119,11 +119,14 @@ public extension UIView {
     fileprivate func size(_ attribute: NSLayoutAttribute,
                           relatedBy: NSLayoutRelation = .equal,
                           points: CGFloat) -> UIView {
+        let c = constraint(item: self,
+                           attribute: attribute,
+                           relatedBy: relatedBy,
+                           constant: points)
         if let spv = superview {
-            let c = constraint(item: self, attribute:attribute,
-                               relatedBy:relatedBy,
-                               constant: points)
             spv.addConstraint(c)
+        } else {
+            addConstraint(c)
         }
         return self
     }

--- a/SteviaTests/SizeTests.swift
+++ b/SteviaTests/SizeTests.swift
@@ -136,4 +136,13 @@ class SizeTests: XCTestCase {
         XCTAssertEqualWithAccuracy(v.frame.height, 192, accuracy: CGFloat(Float.ulpOfOne))
         
     }
+    
+    func testSizeOnOrphanView() {
+        v.removeFromSuperview()
+        v.height(80)
+        ctrler.view.sv(v)
+        ctrler.view.layout(0, |v|)
+        ctrler.view.layoutIfNeeded()
+        XCTAssertEqualWithAccuracy(v.frame.height, 80, accuracy: CGFloat(Float.ulpOfOne))
+    }
 }

--- a/SteviaTests/SizeTests.swift
+++ b/SteviaTests/SizeTests.swift
@@ -140,9 +140,11 @@ class SizeTests: XCTestCase {
     func testSizeOnOrphanView() {
         v.removeFromSuperview()
         v.height(80)
+        v.width(80)
         ctrler.view.sv(v)
-        ctrler.view.layout(0, |v|)
+        ctrler.view.layout(0, |v)
         ctrler.view.layoutIfNeeded()
+        XCTAssertEqualWithAccuracy(v.frame.width, 80, accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqualWithAccuracy(v.frame.height, 80, accuracy: CGFloat(Float.ulpOfOne))
     }
 }


### PR DESCRIPTION
Hi,

Firstable, thanks for this great framework!

With the current version of Stevia, I realised that it is impossible to add a size constraint to a view without a superview. 

Here is an example of what I would like to achieve, and which is not currently doable:

```swift
import UIKit
import Stevia

class SelfSizedView: UIView {

    convenience init() {
        self.init(frame:CGRect.zero)

        backgroundColor = UIColor.red
        height(80)
    }
}

class ViewController: UIViewController {

    let selfSizedView = SelfSizedView()
    let grayView = UIView().style {
        $0.backgroundColor = UIColor.gray
    }

    override func viewDidLoad() {
        super.viewDidLoad()

        view.sv(
            selfSizedView,
            grayView
        ).layout(
            0,
            |selfSizedView|,
            |grayView|,
            0
        )
    }
}

```

Without the fix, the code above produces:

![simulator screen shot 5 mai 2017 a 10 34 16](https://cloud.githubusercontent.com/assets/3514976/25739367/e4ddbbae-3181-11e7-8ddb-f6b37af79925.png)

With the fix, the code above produces:

![simulator screen shot 5 mai 2017 a 10 40 05](https://cloud.githubusercontent.com/assets/3514976/25739378/f025f4e0-3181-11e7-8ea2-f93340ba125f.png)

I also added a unit test to validate that the fix is working.

Best,

Théo