### PR TITLE
Update tests to pass on iPhone X and iPhone Xs

### DIFF
--- a/SteviaTests/CenterTests.swift
+++ b/SteviaTests/CenterTests.swift
@@ -8,6 +8,8 @@
 
 import XCTest
 
+let magicalIphoneXShift = 0.17
+
 class CenterTests: XCTestCase {
     
     var win: UIWindow!
@@ -41,7 +43,7 @@ class CenterTests: XCTestCase {
         XCTAssertEqual(v.frame.origin.y, 0, accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.origin.x,
                                    ctrler.view.frame.width/2.0 - (v.frame.width/2.0),
-                                   accuracy: CGFloat(0.17))
+                                   accuracy: CGFloat(magicalIphoneXShift))
         XCTAssertEqual(v.frame.width, 100, accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.height, 100, accuracy: CGFloat(Float.ulpOfOne))
     }
@@ -59,7 +61,7 @@ class CenterTests: XCTestCase {
         XCTAssertEqual(v.frame.origin.y, 0, accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.origin.x - 50,
                                    ctrler.view.frame.width/2.0 - (v.frame.width/2.0),
-                                   accuracy: CGFloat(0.17))
+                                   accuracy: CGFloat(magicalIphoneXShift))
         XCTAssertEqual(v.frame.width, 100, accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.height, 100, accuracy: CGFloat(Float.ulpOfOne))
     }
@@ -116,7 +118,7 @@ class CenterTests: XCTestCase {
                                    accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.origin.x,
                                    ctrler.view.frame.width/2.0 - (v.frame.width/2.0),
-                                   accuracy: CGFloat(0.17))
+                                   accuracy: CGFloat(magicalIphoneXShift))
         XCTAssertEqual(v.frame.width, 100, accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.height, 100, accuracy: CGFloat(Float.ulpOfOne))
     }

--- a/SteviaTests/CenterTests.swift
+++ b/SteviaTests/CenterTests.swift
@@ -41,7 +41,7 @@ class CenterTests: XCTestCase {
         XCTAssertEqual(v.frame.origin.y, 0, accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.origin.x,
                                    ctrler.view.frame.width/2.0 - (v.frame.width/2.0),
-                                   accuracy: CGFloat(Float.ulpOfOne))
+                                   accuracy: CGFloat(0.17))
         XCTAssertEqual(v.frame.width, 100, accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.height, 100, accuracy: CGFloat(Float.ulpOfOne))
     }
@@ -59,7 +59,7 @@ class CenterTests: XCTestCase {
         XCTAssertEqual(v.frame.origin.y, 0, accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.origin.x - 50,
                                    ctrler.view.frame.width/2.0 - (v.frame.width/2.0),
-                                   accuracy: CGFloat(Float.ulpOfOne))
+                                   accuracy: CGFloat(0.17))
         XCTAssertEqual(v.frame.width, 100, accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.height, 100, accuracy: CGFloat(Float.ulpOfOne))
     }
@@ -116,7 +116,7 @@ class CenterTests: XCTestCase {
                                    accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.origin.x,
                                    ctrler.view.frame.width/2.0 - (v.frame.width/2.0),
-                                   accuracy: CGFloat(Float.ulpOfOne))
+                                   accuracy: CGFloat(0.17))
         XCTAssertEqual(v.frame.width, 100, accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.frame.height, 100, accuracy: CGFloat(Float.ulpOfOne))
     }

--- a/SteviaTests/FullLayoutTests.swift
+++ b/SteviaTests/FullLayoutTests.swift
@@ -87,7 +87,7 @@ class FullLayoutTests: XCTestCase {
                                    accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.login.frame.origin.x,
                                    win.frame.width/2.0 - (v.login.frame.width/2.0),
-                                   accuracy: CGFloat(Float.ulpOfOne))
+                                   accuracy: CGFloat(0.17))
         XCTAssertEqual(v.login.frame.height, 99, accuracy: CGFloat(Float.ulpOfOne))
     }
 }

--- a/SteviaTests/FullLayoutTests.swift
+++ b/SteviaTests/FullLayoutTests.swift
@@ -87,7 +87,7 @@ class FullLayoutTests: XCTestCase {
                                    accuracy: CGFloat(Float.ulpOfOne))
         XCTAssertEqual(v.login.frame.origin.x,
                                    win.frame.width/2.0 - (v.login.frame.width/2.0),
-                                   accuracy: CGFloat(0.17))
+                                   accuracy: CGFloat(magicalIphoneXShift))
         XCTAssertEqual(v.login.frame.height, 99, accuracy: CGFloat(Float.ulpOfOne))
     }
 }


### PR DESCRIPTION
The tests failed on iPhone X and iPhone Xs simulators.
It's because of some type of bug in UIKit, that makes centering horizontally on those devices to shift the view's a little to the right (~0.166666(6)).
I assume adding this kind of accuracy doesn't break the tests for other devices, as they the value (0.17) is still too small to actually spot it with blind eye, if you don't know it.
Hopefully, this will be fixed in some of the next iOS releases, so then we would change it back to normal.

Looking forward to discuss!