### PR TITLE
Fix return type in methods returning self

### DIFF
--- a/Source/Stevia+Center.swift
+++ b/Source/Stevia+Center.swift
@@ -21,7 +21,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func centerInContainer() -> UIView {
+    func centerInContainer() -> Self {
         if let spv = superview {
             alignCenter(self, with: spv)
         }
@@ -39,7 +39,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func centerHorizontally() -> UIView {
+    func centerHorizontally() -> Self {
         if let spv = superview {
             align(vertically: self, spv)
         }
@@ -57,7 +57,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func centerVertically() -> UIView {
+    func centerVertically() -> Self {
         if let spv = superview {
             align(horizontally: self, spv)
         }
@@ -75,7 +75,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func centerHorizontally(_ offset: CGFloat) -> UIView {
+    func centerHorizontally(_ offset: CGFloat) -> Self {
         if let spv = superview {
             alignVertically(self, with: spv, offset: offset)
         }
@@ -93,7 +93,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func centerVertically(_ offset: CGFloat) -> UIView {
+    func centerVertically(_ offset: CGFloat) -> Self {
         if let spv = superview {
             alignHorizontally(self, with: spv, offset: offset)
         }

--- a/Source/Stevia+Constraints.swift
+++ b/Source/Stevia+Constraints.swift
@@ -139,7 +139,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func heightEqualsWidth() -> UIView {
+    func heightEqualsWidth() -> Self {
         if let spv = superview {
             let c = constraint(item: self, attribute: .height, toItem: self, attribute: .width)
             spv.addConstraint(c)

--- a/Source/Stevia+Fill.swift
+++ b/Source/Stevia+Fill.swift
@@ -15,7 +15,7 @@ public extension UIView {
      A padding can be used to apply equal spaces between the view and its superview
     */
     @discardableResult
-    func fillContainer(_ padding: CGFloat = 0) -> UIView {
+    func fillContainer(_ padding: CGFloat = 0) -> Self {
         fillHorizontally(m: padding)
         fillVertically(m: padding)
         return self
@@ -26,7 +26,7 @@ public extension UIView {
      Adds the constraints needed for the view to fill its `superview` Vertically.
      A padding can be used to apply equal spaces between the view and its superview
      */
-    func fillV(m points: CGFloat = 0) -> UIView {
+    func fillV(m points: CGFloat = 0) -> Self {
         return fill(.vertical, points: points)
     }
     
@@ -35,7 +35,7 @@ public extension UIView {
      A padding can be used to apply equal spaces between the view and its superview
      */
     @discardableResult
-    func fillVertically(m points: CGFloat = 0) -> UIView {
+    func fillVertically(m points: CGFloat = 0) -> Self {
         return fill(.vertical, points: points)
     }
     
@@ -44,7 +44,7 @@ public extension UIView {
      Adds the constraints needed for the view to fill its `superview` Horizontally.
      A padding can be used to apply equal spaces between the view and its superview
      */
-    func fillH(m points: CGFloat = 0) -> UIView {
+    func fillH(m points: CGFloat = 0) -> Self {
         return fill(.horizontal, points: points)
     }
     
@@ -53,11 +53,11 @@ public extension UIView {
      A padding can be used to apply equal spaces between the view and its superview
      */
     @discardableResult
-    func fillHorizontally(m points: CGFloat = 0) -> UIView {
+    func fillHorizontally(m points: CGFloat = 0) -> Self {
         return fill(.horizontal, points: points)
     }
     
-    fileprivate func fill(_ axis: NSLayoutConstraint.Axis, points: CGFloat = 0) -> UIView {
+    fileprivate func fill(_ axis: NSLayoutConstraint.Axis, points: CGFloat = 0) -> Self {
         let a: NSLayoutConstraint.Attribute = axis == .vertical ? .top : .left
         let b: NSLayoutConstraint.Attribute = axis == .vertical ? .bottom : .right
         if let spv = superview {

--- a/Source/Stevia+Percentage.swift
+++ b/Source/Stevia+Percentage.swift
@@ -35,7 +35,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func size(_ p: SteviaPercentage) -> UIView {
+    func size(_ p: SteviaPercentage) -> Self {
         width(p)
         height(p)
         return self
@@ -55,7 +55,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func width(_ p: SteviaPercentage) -> UIView {
+    func width(_ p: SteviaPercentage) -> Self {
         if let spv = superview {
             Width == p.value % spv.Width
         }
@@ -82,7 +82,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func height(_ p: SteviaPercentage) -> UIView {
+    func height(_ p: SteviaPercentage) -> Self {
         if let spv = superview {
             Height == p.value % spv.Height
         }
@@ -101,7 +101,7 @@ public extension UIView {
     - Returns: Itself for chaining purposes
      */
     @discardableResult
-    func top(_ p: SteviaPercentage) -> UIView {
+    func top(_ p: SteviaPercentage) -> Self {
         if let spv = superview {
             Top == p.value % spv.Bottom
         }
@@ -120,7 +120,7 @@ public extension UIView {
      - Returns: Itself for chaining purposes
      */
     @discardableResult
-    func left(_ p: SteviaPercentage) -> UIView {
+    func left(_ p: SteviaPercentage) -> Self {
         if let spv = superview {
             Left == p.value % spv.Right
         }
@@ -139,7 +139,7 @@ public extension UIView {
      - Returns: Itself for chaining purposes
      */
     @discardableResult
-    func right(_ p: SteviaPercentage) -> UIView {
+    func right(_ p: SteviaPercentage) -> Self {
         if let spv = superview {
             if p.value == 100 {
                 Right == spv.Left
@@ -162,7 +162,7 @@ public extension UIView {
      - Returns: Itself for chaining purposes
      */
     @discardableResult
-    func bottom(_ p: SteviaPercentage) -> UIView {
+    func bottom(_ p: SteviaPercentage) -> Self {
         if let spv = superview {
             if p.value == 100 {
                 Bottom == spv.Top

--- a/Source/Stevia+Position.swift
+++ b/Source/Stevia+Position.swift
@@ -22,7 +22,7 @@ public extension UIView {
      - Returns: Itself for chaining purposes
      */
     @discardableResult
-    func left(_ points: CGFloat) -> UIView {
+    func left(_ points: CGFloat) -> Self {
         return position(.left, points: points)
     }
     
@@ -38,7 +38,7 @@ public extension UIView {
      - Returns: Itself for chaining purposes
      */
     @discardableResult
-    func right(_ points: CGFloat) -> UIView {
+    func right(_ points: CGFloat) -> Self {
         return position(.right, points: -points)
     }
     
@@ -54,7 +54,7 @@ public extension UIView {
     - Returns: Itself for chaining purposes
     */
     @discardableResult
-    func top(_ points: CGFloat) -> UIView {
+    func top(_ points: CGFloat) -> Self {
         return position(.top, points: points)
     }
     
@@ -70,7 +70,7 @@ public extension UIView {
     - Returns: Itself for chaining purposes
     */
     @discardableResult
-    func bottom(_ points: CGFloat) -> UIView {
+    func bottom(_ points: CGFloat) -> Self {
         return position(.bottom, points: -points)
     }
 
@@ -86,7 +86,7 @@ public extension UIView {
     - Returns: Itself for chaining purposes
     */
     @discardableResult
-    func left(_ fm: SteviaFlexibleMargin) -> UIView {
+    func left(_ fm: SteviaFlexibleMargin) -> Self {
         return position(.left, relatedBy: fm.relation, points: fm.points)
     }
     
@@ -102,7 +102,7 @@ public extension UIView {
     - Returns: Itself for chaining purposes
     */
     @discardableResult
-    func right(_ fm: SteviaFlexibleMargin) -> UIView {
+    func right(_ fm: SteviaFlexibleMargin) -> Self {
         // For right this should be inverted.
         var n = SteviaFlexibleMargin()
         n.points = -fm.points
@@ -127,7 +127,7 @@ public extension UIView {
     - Returns: Itself for chaining purposes
      */
     @discardableResult
-    func top(_ fm: SteviaFlexibleMargin) -> UIView {
+    func top(_ fm: SteviaFlexibleMargin) -> Self {
         return position(.top, relatedBy: fm.relation, points: fm.points)
     }
     
@@ -143,7 +143,7 @@ public extension UIView {
     - Returns: Itself for chaining purposes
     */
     @discardableResult
-    func bottom(_ fm: SteviaFlexibleMargin) -> UIView {
+    func bottom(_ fm: SteviaFlexibleMargin) -> Self {
         // For bottom this should be inverted.
         var n = SteviaFlexibleMargin()
         n.points = -fm.points
@@ -158,7 +158,7 @@ public extension UIView {
     
     fileprivate func position(_ position: NSLayoutConstraint.Attribute,
                               relatedBy: NSLayoutConstraint.Relation = .equal,
-                              points: CGFloat) -> UIView {
+                              points: CGFloat) -> Self {
         if let spv = superview {
             let c = constraint(item: self, attribute: position,
                                relatedBy: relatedBy,

--- a/Source/Stevia+Size.swift
+++ b/Source/Stevia+Size.swift
@@ -26,7 +26,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func size(_ points: CGFloat) -> UIView {
+    func size(_ points: CGFloat) -> Self {
         width(points)
         height(points)
         return self
@@ -52,7 +52,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func height(_ points: CGFloat) -> UIView {
+    func height(_ points: CGFloat) -> Self {
         return size(.height, points: points)
     }
     
@@ -70,7 +70,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func width(_ points: CGFloat) -> UIView {
+    func width(_ points: CGFloat) -> Self {
         return size(.width, points: points)
     }
     
@@ -94,7 +94,7 @@ public extension UIView {
      
      */
     @discardableResult
-    func height(_ fm: SteviaFlexibleMargin) -> UIView {
+    func height(_ fm: SteviaFlexibleMargin) -> Self {
         return size(.height, relatedBy: fm.relation, points: fm.points)
     }
     
@@ -112,13 +112,13 @@ public extension UIView {
      
      */
     @discardableResult
-    func width(_ fm: SteviaFlexibleMargin) -> UIView {
+    func width(_ fm: SteviaFlexibleMargin) -> Self {
         return size(.width, relatedBy: fm.relation, points: fm.points)
     }
     
     fileprivate func size(_ attribute: NSLayoutConstraint.Attribute,
                           relatedBy: NSLayoutConstraint.Relation = .equal,
-                          points: CGFloat) -> UIView {
+                          points: CGFloat) -> Self {
         let c = constraint(item: self,
                            attribute: attribute,
                            relatedBy: relatedBy,


### PR DESCRIPTION
I think it would be useful to preserve the initial view type during chaining.

```swift
// imageView will be UIImageView  
let imageView = UIImageView()
        .width(100)
        .height(50)

// at some point
imageView.image = UIImage()
```