### PR TITLE
FIX Preprocessor flag `#if canImport(UIKit)` moved to wrap all UIKit related types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 Put unreleased changes here
+- Preprocessor flag `#if canImport(UIKit)` moved to wrap all UIKit related types.
 
 ## [4.6.0] - 2019-09-30
 ### Changed

--- a/Sources/Stevia/Stevia+Stacks.swift
+++ b/Sources/Stevia/Stevia+Stacks.swift
@@ -6,6 +6,9 @@
 //  Copyright © 2016 Sacha Durand Saint Omer. All rights reserved.
 //
 
+#if canImport(UIKit)
+import UIKit
+
 //enum SteviaLayoutItemType {
 //
 //}
@@ -47,9 +50,6 @@ public extension UIView {
         return self
     }
 }
-
-#if canImport(UIKit)
-import UIKit
 
 public extension UIView {
     


### PR DESCRIPTION
The `#if canImport(UIKit)` flag was positioned lower than it should in the `Stevia+Stacks.swift` file