### PR TITLE
Create Int and CGFloat variants for SteviaLayoutAnchor operators

### DIFF
--- a/Sources/Stevia/Stevia+LayoutAnchors.swift
+++ b/Sources/Stevia/Stevia+LayoutAnchors.swift
@@ -145,6 +145,54 @@ public func - (left: SteviaLayoutXAxisAnchor, right: Double) -> SteviaLayoutXAxi
     return SteviaLayoutXAxisAnchor(anchor: left.anchor, constant: -right)
 }
 
+@available(iOS 9.0, *)
+@discardableResult
+public func + (left: SteviaLayoutYAxisAnchor, right: CGFloat) -> SteviaLayoutYAxisAnchor {
+    return SteviaLayoutYAxisAnchor(anchor: left.anchor, constant: Double(right))
+}
+
+@available(iOS 9.0, *)
+@discardableResult
+public func - (left: SteviaLayoutYAxisAnchor, right: CGFloat) -> SteviaLayoutYAxisAnchor {
+    return SteviaLayoutYAxisAnchor(anchor: left.anchor, constant: Double(-right))
+}
+
+@available(iOS 9.0, *)
+@discardableResult
+public func + (left: SteviaLayoutXAxisAnchor, right: CGFloat) -> SteviaLayoutXAxisAnchor {
+    return SteviaLayoutXAxisAnchor(anchor: left.anchor, constant: Double(right))
+}
+
+@available(iOS 9.0, *)
+@discardableResult
+public func - (left: SteviaLayoutXAxisAnchor, right: CGFloat) -> SteviaLayoutXAxisAnchor {
+    return SteviaLayoutXAxisAnchor(anchor: left.anchor, constant: Double(-right))
+}
+
+@available(iOS 9.0, *)
+@discardableResult
+public func + (left: SteviaLayoutYAxisAnchor, right: Int) -> SteviaLayoutYAxisAnchor {
+    return SteviaLayoutYAxisAnchor(anchor: left.anchor, constant: Double(right))
+}
+
+@available(iOS 9.0, *)
+@discardableResult
+public func - (left: SteviaLayoutYAxisAnchor, right: Int) -> SteviaLayoutYAxisAnchor {
+    return SteviaLayoutYAxisAnchor(anchor: left.anchor, constant: Double(-right))
+}
+
+@available(iOS 9.0, *)
+@discardableResult
+public func + (left: SteviaLayoutXAxisAnchor, right: Int) -> SteviaLayoutXAxisAnchor {
+    return SteviaLayoutXAxisAnchor(anchor: left.anchor, constant: Double(right))
+}
+
+@available(iOS 9.0, *)
+@discardableResult
+public func - (left: SteviaLayoutXAxisAnchor, right: Int) -> SteviaLayoutXAxisAnchor {
+    return SteviaLayoutXAxisAnchor(anchor: left.anchor, constant: Double(-right))
+}
+
 // UILayoutSupport
 
 @available(iOS 9.0, *)


### PR DESCRIPTION
As discussed on issue #153 `SteviaLayoutAnchor` operators are lacking `Int` and `CGFloat` variants of operators `+` and `-`.

This PR adds operator variants that proxies to the `Double` operator like it's done with `SteviaAttribute` operators.