### PR TITLE
Added podspec. Cocoapods.

### DIFF
--- a/Stevia.podspec
+++ b/Stevia.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name             = 'Stevia'
+  s.version          = "5.1.1"
+  s.summary          = "Elegant view layout for iOS"
+  s.homepage         = "https://github.com/s4cha/Stevia"
+  s.license          = { :type => "MIT", :file => "LICENSE" }
+  s.author           = 'S4cha'
+  s.source           = { :git => "https://github.com/s4cha/Stevia.git",
+                         :tag => s.version.to_s }
+  s.social_media_url = 'https://twitter.com/sachadso'
+  s.source_files     = "Sources/Stevia/*.swift"
+  s.ios.deployment_target = "9"
+  s.tvos.deployment_target = "10.2"
+  s.description  = "Elegant view layout for iOS :leaves: - Auto layout code finally readable by a human being"
+  s.module_name = 'Stevia'
+end


### PR DESCRIPTION
I really need cocoapods back for this!

I ask to remove unused Stevia namespace from cocoapods: https://github.com/CocoaPods/trunk.cocoapods.org/issues/321
Me and people ask to bring back cocoapods: https://github.com/freshOS/Stevia/issues/137

Some reasons to add it back:

- @NikKovIos For Yummypets/YPImagePicker I can't make a new release because Stevia in SPM doesn't support old version of functions and cocoapods not support new names of functions. But YPImagePicker support the both - SPM and cocoapods.
- SPM is a big problem if you haven't internet connection or it is slow.
- @useobjc "I would like to build the pod library as a static library, so that I can get a smaller IPA file size."
- @sdykae "I cant elaborate but my company works with many ipads 4th gen with just ios 10 support, there is no way to get spm on their stack xcode10"