### PR TITLE
remove deprecation warnings on all double-dash operators

### DIFF
--- a/Sources/Stevia/Stevia+DoubleDash.swift
+++ b/Sources/Stevia/Stevia+DoubleDash.swift
@@ -12,127 +12,106 @@ import UIKit
 infix operator -- :AdditionPrecedence
 
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: UIView, right: Double) -> PartialConstraint {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 public func -- (left: UIView, right: CGFloat) -> PartialConstraint {
     return left--Double(right)
 }
 
-@available(*, deprecated, renamed: "⁃")
 public func -- (left: UIView, right: Int) -> PartialConstraint {
     return left--Double(right)
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: SideConstraint, right: UIView) -> UIView {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: [UIView], right: SideConstraint) -> [UIView] {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: UIView, right: SideConstraint) -> UIView {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: PartialConstraint, right: UIView) -> [UIView] {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: UIView, right: UIView) -> [UIView] {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: [UIView], right: Double) -> PartialConstraint {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: [UIView], right: CGFloat) -> PartialConstraint {
     return left--Double(right)
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: [UIView], right: Int) -> PartialConstraint {
     return left--Double(right)
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: [UIView], right: UIView) -> [UIView] {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: UIView, right: String) -> Space {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: [UIView], right: String) -> Space {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: Space, right: UIView) -> [UIView] {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: UIView,
                 right: SteviaFlexibleMargin) -> PartialFlexibleConstraint {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: [UIView],
                 right: SteviaFlexibleMargin) -> PartialFlexibleConstraint {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: PartialFlexibleConstraint, right: UIView) -> [UIView] {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: SteviaLeftFlexibleMargin, right: UIView) -> UIView {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: UIView, right: SteviaRightFlexibleMargin) -> UIView {
     return left-right
 }
 
-@available(*, deprecated, renamed: "⁃")
 @discardableResult
 public func -- (left: [UIView], right: SteviaRightFlexibleMargin) -> [UIView] {
     return left-right


### PR DESCRIPTION
I use Stevia in a rather large app and have recently been digging into why my compile times are terribly slow.  For context, doing a "clean build" takes ~9 minutes on my laptop.  I've been going through with the swift compiler flag for `-Xfrontend -debug-time-function-bodies`  to help assist where our issues lie and it turns out that all my (beloved) Stevia layout blocks are a huge part of my problem.  

Way back in the swift 2 timeframe, we had to have the `--` operator because XCode would fail to compile saying "the statement was to complex to evaluate" (assume you remember that well @s4cha ).  While XCode has long since stopped choking like that, it turns out that the `--` is still massively superior to the `-` when you look at compile times.

For example, I have a method that has 8 lines of Stevia's chaining APIs followed by this simple layout block with 3 views on one line.  This method is taking  4,057ms to compile! (yes 4 seconds).  
```swift
private func configureViewLayout() {
    contentView.fillVertically().fillHorizontally(padding: 12)
    contentStackView.fillContainer()
    petImageStackView.fillContainer(padding: 4)
    flashlightButtonContentView.size(50)
    petImageView.centerInContainer().size(25)
    lightIndicator.centerInContainer().size(32)
    disclosureIndicator.width(10)
    petPillView.fillHorizontally().centerInContainer()

    petInfoContainerView.layout {
        0
        |-0 - petStatusImageView.width(14) - 8 - petNameLabel - 8 - batteryIndicator.height(14) - 0-|
        0
    }
}
```

If I change the main line of the layout block to use the double dash `--` operator like the following, then compile time on this method drops to 37ms.  (yes it drops from 4075 to 37, that's huge, shaving 99% off the compile time)
```swift
petInfoContainerView.layout {
    0
    |-0 -- petStatusImageView.width(14.0) -- 8 -- petNameLabel -- 8 -- batteryIndicator.height(14.0) -- 0-|
    0
}
```

I've got north of 150 views that I'm scrubbing through and switching to double-dashes and it's going to end up saving multiple minutes of compile time  - which is outstanding... 

...but every instance of `--` is now generating compiler warning - so I've suddenly got hundreds of compiler warnings about the `--` being deprecated.  

Given this evidence, I think it's really relevant to un-deprecate the double-dash operator as it definitely has an important use.  

hope you agree.