### PR TITLE
Issue #181 Xcode 26 Fix.

### DIFF
--- a/Sources/Stevia/Stevia+Center.swift
+++ b/Sources/Stevia/Stevia+Center.swift
@@ -24,7 +24,7 @@ public extension UIView {
     @discardableResult
     func centerInContainer() -> Self {
         if let spv = superview {
-            alignCenter(self, with: spv)
+          Stevia.alignCenter(self, with: spv)
         }
         return self
     }

--- a/Sources/Stevia/Stevia+Constraints.swift
+++ b/Sources/Stevia/Stevia+Constraints.swift
@@ -10,7 +10,7 @@
 import UIKit
 
 public class SteviaLayoutConstraint: NSLayoutConstraint {
-    public static var defaultPriority: Float = UILayoutPriority.defaultHigh + 1
+    public static var defaultPriority: Float = Float(UILayoutPriority.defaultHigh + 1)
 }
 
 


### PR DESCRIPTION
Namespaces alignCenter so it doesn't conflict with Foundation addition in os 26